### PR TITLE
allow rate < 1

### DIFF
--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -8,6 +8,7 @@ import token_bucket
 
 
 @pytest.mark.parametrize('rate,capacity', [
+    (0.3, 1),
     (1, 1),
     (2.5, 1),  # Fractional rates are valid
     (10, 100),  # Long recovery time after bursting

--- a/token_bucket/limiter.py
+++ b/token_bucket/limiter.py
@@ -69,8 +69,8 @@ class Limiter(object):
         if not isinstance(rate, (float, int)):
             raise TypeError('rate must be an int or float')
 
-        if rate < 1:
-            raise ValueError('rate must be >= 1')
+        if rate <= 0:
+            raise ValueError('rate must be > 0')
 
         if not isinstance(capacity, int):
             raise TypeError('capacity must be an int')


### PR DESCRIPTION
Closes #8 

(added by @vytas7 :arrow_upper_left: )

Since fractional rates are allowed I don't see any reason to prevent `rate < 1`

so this changes to validate `rate > 0`