### PR TITLE
Provide a MANIFEST.in to include extras in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include tests/*
+include tools/*
+include requirements/test
+include tox.ini


### PR DESCRIPTION
Includes tox.ini, tests, requirements, and tools into the default sdist
that is uploaded to (for example PyPi). This allows for easier builds
and testing for package maintainers.

This closes #17.