### PR TITLE
Allow user to override the Limiter subclass check

### DIFF
--- a/token_bucket/limiter.py
+++ b/token_bucket/limiter.py
@@ -65,7 +65,7 @@ class Limiter(object):
         '_storage',
     )
 
-    def __init__(self, rate, capacity, storage):
+    def __init__(self, rate, capacity, storage, ignore_subclass: bool = False):
         if not isinstance(rate, (float, int)):
             raise TypeError('rate must be an int or float')
 
@@ -78,7 +78,7 @@ class Limiter(object):
         if capacity < 1:
             raise ValueError('capacity must be >= 1')
 
-        if not isinstance(storage, StorageBase):
+        if not isinstance(storage, StorageBase) and not ignore_subclass:
             raise TypeError('storage must be a subclass of StorageBase')
 
         self._rate = rate


### PR DESCRIPTION
I added the arg `ignore_subclass` to `Limiter` to enable the user to skip the `storage must be a subclass of StorageBase` check.

Here is my use-case:

```python
from multiprocessing.managers import BaseManager
from token_bucket import Limiter, MemoryStorage

class LimiterManager(BaseManager):
    pass

LimiterManager.register('Limiter', Limiter)
LimiterManager.register('MemoryStorage', MemoryStorage)

manager = LimiterManager()
manager.start()

self.manager.Limiter(rate=max_requests_per_second, capacity=max_requests_per_second, storage=self.manager.MemoryStorage(), ignore_subclass=True)
```

As you can see, I am using multiprocessing's `BaseManager` to share the `Limiter` and `MemoryStorage` objects with `multiprocessing.Process()` processes. Without `ignore_subclass`, the subclass check fails. 