### PR TITLE
Drop pytest-runner and "setup.py test" support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,4 @@ setup(
     packages=find_packages(exclude=['tests']),
     python_requires='>=3.7',
     install_requires=[],
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
 )


### PR DESCRIPTION
Removes `pytest-runner` from `setup_requires`, and remove `test_requires`, which is deprecated and only useful with `setup.py test`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or `tox`.

This is a very small, targeted fix; it would be superseded by any larger build-system modernization like https://github.com/falconry/token-bucket/pull/26 or https://github.com/falconry/token-bucket/pull/23.